### PR TITLE
Support for Unicode language/territory codes like 'es-MX'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,12 +13,12 @@ Add the gem to your Gemfile.
 == Usage
 
 ==== General Options
-* <tt>:locale</tt> - Sets the locale to be used for formatting (defaults to current locale).
-* <tt>:currency</tt> - Sets the denomination of the currency (defaults to +:default+ currency for the locale or "dollar" if not set).
-* <tt>:connector</tt> - Sets the connector between integer part and decimal part of the currency (defaults to ", ").
-* <tt>:format</tt> - Sets the format for non-negative numbers (defaults to "%n").
+* <tt>:locale</tt> - Sets the locale to be used for formatting. Defaults to 'en' (English). Unicode language and territory codes can be used, such as 'es-MX' (Spanish, Mexico).
+* <tt>:currency</tt> - Sets the denomination of the currency. Defaults to +:default+ currency for the locale or "dollar" if not set.
+* <tt>:connector</tt> - Sets the connector between integer part and decimal part of the currency. Defaults to ", ".
+* <tt>:format</tt> - Sets the format for non-negative numbers. Defaults to "%n".
 Field is <tt>%n</tt> for the currency amount in words.
-* <tt>:negative_format</tt> - Sets the format for negative numbers (defaults to prepending "minus" to the number in words 'minus %n').
+* <tt>:negative_format</tt> - Sets the format for negative numbers. Defaults to prepending "minus" to the number in words 'minus %n'.
 Field is <tt>%n</tt> for the currency amount in words (same as format).
 
 ===== Examples

--- a/lib/currency-in-words.rb
+++ b/lib/currency-in-words.rb
@@ -81,12 +81,13 @@ module CurrencyInWords
           return e.number.to_s.html_safe? ? rounded_number.html_safe : rounded_number
         end
       end
-
+      
+      inferred_klass_name = options[:locale].to_s.sub(/([a-z]{2})(-([a-z]{2}))?/i){|s| $1 ? ($1[0].upcase + $1[1].downcase + ($3 ? $3.upcase : '')) : s }
       begin
-        klass = "CurrencyInWords::#{options[:locale].to_s.capitalize}Texterizer".constantize
+        klass = "CurrencyInWords::#{inferred_klass_name}Texterizer".constantize
       rescue NameError
         if options[:raise]
-          raise NameError, "Implement a class #{options[:locale].to_s.capitalize}Texterizer to support this locale, please."
+          raise NameError, "Implement a class #{inferred_klass_name}Texterizer to support this locale, please."
         else
           klass = EnTexterizer
         end


### PR DESCRIPTION
Support for Unicode language/territory codes like 'es-MX' which would correspond to a `CurrencyInWords::EsMXTexterizer` class.
